### PR TITLE
kmscon module

### DIFF
--- a/nixos/hC.nix
+++ b/nixos/hC.nix
@@ -1,0 +1,37 @@
+{ lib, ... }:
+{
+  options.hostConf = {
+    displayType = lib.mkOption {
+      type = lib.types.enum [
+        "headless"
+        "kmscon"
+        "wayland"
+      ];
+      default = "headless";
+      example = "wayland";
+      description = "Configure the system for a headless server, a KMS console, or a Wayland desktop environment.";
+    };
+    tags = lib.mkOption {
+      type = lib.types.listOf lib.types.enum [
+        "power-save" # Laptops & small arm devices
+        "gaming" # High performance gaming
+        "rt-audio" # Real-time audio
+      ];
+      default = "";
+      example = "gaming rt-audio";
+      description = "";
+    };
+    inputType = lib.mkOption {
+      type = lib.types.enum [
+        "controller"
+        "keyboard"
+        "mouse"
+        "touch"
+        "trackpad"
+      ];
+      default = "keyboard";
+      example = "mouse";
+      description = "Configure the system UI for input devices such as a keyboard, mouse, touch screen, trackpad, or controller.";
+    };
+  };
+}

--- a/nixos/hostConfig.nix
+++ b/nixos/hostConfig.nix
@@ -1,38 +1,42 @@
 { lib, ... }:
 {
-
   options.hostConf = {
-    displayType = lib.mkOption {
-      type = lib.types.enum [
-        "headless"
-        "kmscon"
-        "wayland"
-      ];
-      default = "headless";
-      example = "wayland";
-      description = "Configure the system for a headless server, a KMS console, or a Wayland desktop environment.";
+    displayType = {
+      headless = lib.mkEnableOption;
+      wayland = lib.mkEnableOption;
+      kmscon = lib.mkOption {
+        type = lib.types.list;
+        default = "";
+        description = "list of ttys that will be enabled with kms console";
+      };
     };
-    tags = lib.mkOption {
-      type = lib.types.listOf lib.types.enum [
-        "power-save" # Laptops & small arm devices
-        "gaming" # High performance gaming
-        "rt-audio" # Real-time audio
-      ];
+    agetty = lib.mkOption {
+      type = lib.types.list;
       default = "";
-      example = "gaming rt-audio";
-      description = "";
-    };
-    inputType = lib.mkOption {
-      type = lib.types.enum [
-        "controller"
-        "keyboard"
-        "mouse"
-        "touch"
-        "trackpad"
-      ];
-      default = "keyboard";
-      example = "mouse";
-      description = "Configure the system UI for input devices such as a keyboard, mouse, touch screen, trackpad, or controller.";
+      description = "list of ttys that will use the default console";
     };
   };
+  tags = lib.mkOption {
+    type = lib.types.listOf lib.types.enum [
+      "power-save" # Laptops & small arm devices
+      "gaming" # High performance gaming
+      "rt-audio" # Real-time audio
+    ];
+    default = "";
+    example = "gaming rt-audio";
+    description = "";
+  };
+  inputType = lib.mkOption {
+    type = lib.types.enum [
+      "controller"
+      "keyboard"
+      "mouse"
+      "touch"
+      "trackpad"
+    ];
+    default = "keyboard";
+    example = "mouse";
+    description = "Configure the system UI for input devices such as a keyboard, mouse, touch screen, trackpad, or controller.";
+  };
+
 }

--- a/nixos/services/kmscon.nix
+++ b/nixos/services/kmscon.nix
@@ -1,0 +1,78 @@
+##
+## KNOWN ISSUE: enabling kmscon@tty1 causes it to take over ttys, I think cause of seats or something idk
+##
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+
+  cfg = config.ff.services.kmscon;
+
+  baseArgs =
+    [
+      "--login-program"
+      "${pkgs.shadow}/bin/login"
+    ]
+    ++ lib.optionals (cfg.autologinUser != null) [
+      "--autologin"
+      cfg.autologinUser
+    ];
+
+  gettyCmd = args: "${lib.getExe' pkgs.util-linux "agetty"} ${lib.escapeShellArgs baseArgs} ${args}";
+
+in
+{
+  options.ff.services.kmscon = {
+
+    enable = lib.mkEnableOption "Enable kms console";
+
+    autologinUser = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Username of the account that will be automatically logged in at the console.
+        If unspecified, a login prompt is shown as usual.
+      '';
+    };
+
+    disableAt = lib.mkOption {
+      type = lib.types.nullOr (lib.types.listOf lib.types.str);
+      default = null;
+      description = "Numeric identifier of ttys that should not use the kms console";
+      example = [
+        "tty2"
+      ];
+    };
+
+  };
+  config = lib.mkIf cfg.enable {
+
+    services.kmscon.enable = true;
+
+    systemd = lib.mkIf (cfg.disableAt != null) {
+
+      services = lib.mkMerge (
+        builtins.map (ttyId: {
+
+          "kmsconvt@${ttyId}".enable = false;
+
+          "getty@${ttyId}" = {
+            enable = true;
+            wantedBy = [ "default.target" ];
+            serviceConfig.ExecStart = [
+              "" # override upstream default with an empty ExecStart
+              (gettyCmd "--noclear --keep-baud pts/${ttyId} 115200,38400,9600 $TERM")
+            ];
+            environment.TTY = "${ttyId}";
+            restartIfChanged = false;
+            aliases = [ "autovt@${ttyId}.service" ];
+          };
+        }) cfg.disableAt
+      );
+    };
+  };
+}


### PR DESCRIPTION
Add a module that optionally enables the kms console service, and can optionally replace it with agetty at specific ttys.

Known issues: enabling kmsconvt@tty1 causes kmscon to take over all ttys, I believe this is supposed to happen by default but we probably don't want it to. Also need to add some more options for specific settings for either.